### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through a stack trace

### DIFF
--- a/supabase/functions/notify-new-subscriber/index.ts
+++ b/supabase/functions/notify-new-subscriber/index.ts
@@ -129,12 +129,8 @@ serve(async (req) => {
           JSON.stringify({ 
             success: false, 
             emailSent: false, 
-            error: emailError.message,
-            errorName: emailError.constructor.name,
-            timestamp: new Date().toISOString(),
-            stack: emailError.stack,
-            cause: emailError.cause,
-            response: emailError.response
+            error: "An internal error occurred. Please try again later.",
+            timestamp: new Date().toISOString()
           }),
           {
             status: 500,


### PR DESCRIPTION
Potential fix for [https://github.com/joblas/cbarrgs-vibe-haven/security/code-scanning/7](https://github.com/joblas/cbarrgs-vibe-haven/security/code-scanning/7)

To fix the issue, the stack trace (`emailError.stack`) and other sensitive details should be removed from the JSON response sent to the client. Instead, these details should be logged on the server for debugging purposes. The client should receive a generic error message that does not reveal internal implementation details. Specifically:
1. Remove `stack`, `cause`, and `response` from the JSON response on lines 135-137.
2. Log the stack trace and other sensitive details on the server using `console.error`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
