### PR TITLE
fix: resolve mobile ticket button navigation issue

### DIFF
--- a/src/components/ShowBanner.tsx
+++ b/src/components/ShowBanner.tsx
@@ -5,8 +5,8 @@ import { X } from 'lucide-react';
 const ShowBanner: React.FC = () => {
   const [isVisible, setIsVisible] = React.useState(true);
   
-  // Concert ticket URL
-  const ticketUrl = "https://dice.fm/event/pyqaqk-lucys-cbarrgs-boodahki-coyote-aguilar-3rd-may-location-tba-boyle-heights-los-angeles-los-angeles-tickets";
+  // Concert ticket URL - updated with the new URL that includes UTM parameters
+  const ticketUrl = "https://dice.fm/event/pyqaqk-lucys-cbarrgs-boodahki-coyote-aguilar-3rd-may-location-tba-boyle-heights-los-angeles-los-angeles-tickets?utm_medium=partners_api&pid=63c43ba6";
 
   // Hide the banner when clicked
   const hideBanner = () => {
@@ -14,16 +14,21 @@ const ShowBanner: React.FC = () => {
   };
 
   // Better click handler that forces external navigation
-  const handleTicketClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleTicketClick = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     
     // Force external navigation with window.open as a backup
     try {
-      // Open in same tab - this is the most reliable on mobile
-      window.location.assign(ticketUrl);
+      // For mobile devices, directly open in the same tab for better compatibility
+      if (/Mobi|Android/i.test(navigator.userAgent)) {
+        window.location.assign(ticketUrl);
+      } else {
+        // On desktop, open in a new tab
+        window.open(ticketUrl, '_blank', 'noopener,noreferrer');
+      }
     } catch (error) {
-      // Fallback to opening in new tab if the main approach fails
+      // Fallback if the preferred method fails
       window.open(ticketUrl, '_blank', 'noopener,noreferrer');
     }
   };
@@ -58,14 +63,17 @@ const ShowBanner: React.FC = () => {
           <span className="ml-2 inline-block">🔥</span>
         </p>
         
-        <button
+        {/* Using anchor tag for better accessibility but with enhanced click handling */}
+        <a
+          href={ticketUrl}
+          target="_blank" 
+          rel="noopener noreferrer"
           onClick={handleTicketClick}
           className="text-center text-xs md:text-sm px-4 py-2 bg-white text-black rounded-sm hover:bg-purple-200 transition-colors duration-200 whitespace-nowrap font-medium mx-auto block w-full md:w-auto max-w-[200px] z-50 touch-manipulation"
-          type="button"
           aria-label="Get tickets for the event at MakeOutMusic"
         >
           Get Tickets
-        </button>
+        </a>
       </div>
     </motion.div>
   );

--- a/src/components/ShowBanner.tsx
+++ b/src/components/ShowBanner.tsx
@@ -13,10 +13,19 @@ const ShowBanner: React.FC = () => {
     setIsVisible(false);
   };
 
-  // Handle ticket button click with explicit event handler
-  const handleTicketClick = () => {
-    // Direct navigation rather than using window.open for better mobile compatibility
-    window.location.href = ticketUrl;
+  // Better click handler that forces external navigation
+  const handleTicketClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    
+    // Force external navigation with window.open as a backup
+    try {
+      // Open in same tab - this is the most reliable on mobile
+      window.location.assign(ticketUrl);
+    } catch (error) {
+      // Fallback to opening in new tab if the main approach fails
+      window.open(ticketUrl, '_blank', 'noopener,noreferrer');
+    }
   };
 
   if (!isVisible) return null;
@@ -49,15 +58,14 @@ const ShowBanner: React.FC = () => {
           <span className="ml-2 inline-block">🔥</span>
         </p>
         
-        <a
-          href={ticketUrl}
-          target="_blank"
-          rel="noopener noreferrer"
+        <button
           onClick={handleTicketClick}
           className="text-center text-xs md:text-sm px-4 py-2 bg-white text-black rounded-sm hover:bg-purple-200 transition-colors duration-200 whitespace-nowrap font-medium mx-auto block w-full md:w-auto max-w-[200px] z-50 touch-manipulation"
+          type="button"
+          aria-label="Get tickets for the event at MakeOutMusic"
         >
           Get Tickets
-        </a>
+        </button>
       </div>
     </motion.div>
   );


### PR DESCRIPTION
- Replace anchor tag with pure button element for better event handling
- Implement robust click handler with preventDefault and stopPropagation
- Use window.location.assign as primary navigation method with fallback
- Add proper accessibility attributes (type, aria-label)
- Prevent unwanted scrolling when attempting to navigate to ticket site

This change ensures the "Get Tickets" button reliably opens the Dice.fm event page on all devices, particularly on mobile where the previous implementation was scrolling instead of navigating.