### PR TITLE
Potential fix for code scanning alert no. 13: Clear-text logging of sensitive information

### DIFF
--- a/supabase/functions/notify-new-subscriber/index.ts
+++ b/supabase/functions/notify-new-subscriber/index.ts
@@ -20,11 +20,11 @@ const resend = resendApiKey ? new Resend(resendApiKey) : null;
 
 console.log("=================== FUNCTION INITIALIZATION ===================");
 console.log(`Function initialized at: ${new Date().toISOString()}`);
-console.log(`Resend API key configured: ${resendApiKey ? "Yes (masked)" : "No"}`);
-if (resendApiKey) {
-  console.log(`API Key length: ${resendApiKey.length}`);
-  console.log(`API Key first/last chars: ${resendApiKey.substring(0, 2)}...${resendApiKey.substring(resendApiKey.length - 2)}`);
-}
+console.log(`Resend API key configured: ${resendApiKey ? "Yes (present)" : "No"}`);
+
+
+
+
 
 // Helper function to validate email
 function isValidEmail(email: string): boolean {


### PR DESCRIPTION
Potential fix for [https://github.com/joblas/cbarrgs-vibe-haven/security/code-scanning/13](https://github.com/joblas/cbarrgs-vibe-haven/security/code-scanning/13)

In general, to fix clear-text logging of sensitive information, remove or heavily sanitize any logging that includes secrets, tokens, passwords, API keys, or similar. If operational visibility is required, only log non-sensitive metadata (e.g., whether a key is configured) and avoid including any real bytes of the secret.

For this specific code, the best minimal fix is:
- Keep the diagnostic that indicates whether an API key is configured.
- Remove the logs that print the key’s length and its first/last characters, because both leak information about the secret.
- Do not change how `resendApiKey` is obtained or used, only its logging.

Concretely, in `supabase/functions/notify-new-subscriber/index.ts`:
- Around lines 21–27, keep:
  - The initialization banners.
  - `console.log(\`Resend API key configured: ...\`)`.
- Delete the `if (resendApiKey) { ... }` block that logs the length and first/last characters.
No new helper methods or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
